### PR TITLE
Remove storybook-addons from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "shelljs": "^0.7.4"
   },
   "peerDependencies": {
-    "@kadira/storybook-addons": "^1.5.0",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   }


### PR DESCRIPTION
@kadira/storybook-addons is already a dependency of "@kadira/storybook". You shouldn't need to install in manually.